### PR TITLE
#1: set centos:7 explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM centos:7
 MAINTAINER Marty Sullivan <marty.sullivan@cornell.edu>
 
 # Compile Environment


### PR DESCRIPTION
Change base container image from centos to centos:7

closes #1